### PR TITLE
Copy .dll files to game folder (support for extensions)

### DIFF
--- a/PizzaOven/ModLoader.cs
+++ b/PizzaOven/ModLoader.cs
@@ -148,6 +148,14 @@ namespace PizzaOven
                     }
                     successes++;
                 }
+                // Extension .dll files
+                else if (extension.Equals(".dll", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    // Copy over file to game folder
+                    File.Copy(modFile, $"{Global.config.ModsFolder}{Global.s}{Path.GetFileName(modFile)}", true);
+                    Global.logger.WriteLine($"Copied over {modFile} to game folder", LoggerType.Info);
+                    successes++;
+                }
             }
             if (successes == 0)
                 Global.logger.WriteLine($"No file was used from the current mod", LoggerType.Error);


### PR DESCRIPTION
This PR makes Pizza Oven copy .dll files in mod folders to the game folder, which allows mods which use additional extensions (like NekoPresence) to be PO-compatible.
(There's not really any additional security issues, as .exe patching was a thing before, and mod language files could already overwrite the vanilla English language file.)

Seems to work fine from manual testing.